### PR TITLE
Fall back to STDIN instead of a fixed string

### DIFF
--- a/qrcode-terminal.go
+++ b/qrcode-terminal.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"ioutil"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -84,12 +84,12 @@ func main() {
 	}
 
 	if content = flag.Arg(0); content == "" {
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		content = string(data)
+		content = strings.TrimSuffix(string(data), "\n")
 	}
 
 	qr, err := qrcode.New(content, level)

--- a/qrcode-terminal.go
+++ b/qrcode-terminal.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -83,7 +84,12 @@ func main() {
 	}
 
 	if content = flag.Arg(0); content == "" {
-		content = "https://github.com/dawndiy/qrcode-terminal"
+		data, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		content = string(data)
 	}
 
 	qr, err := qrcode.New(content, level)


### PR DESCRIPTION
This makes stuff like `cat ~/.ssh/id_rsa.pub | qrcode-terminal` possible.

Didn't test it yet, will add a comment after I did. :)